### PR TITLE
Move to new rust api

### DIFF
--- a/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
@@ -110,4 +110,30 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
                 .pour(promise);
     }
 
+    // UnitInterval
+
+    @ReactMethod
+    public final void unitIntervalToBytes(String unitInterval, Promise promise) {
+        Native.I
+                .unitIntervalToBytes(new RPtr(unitInterval))
+                .map(bytes -> Base64.encodeToString(bytes, Base64.DEFAULT))
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void unitIntervalFromBytes(String bytes, Promise promise) {
+        Native.I
+                .unitIntervalFromBytes(Base64.decode(bytes, Base64.DEFAULT))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void unitIntervalNew(Double index0, Double index1, Promise promise) {
+        Native.I
+                .unitIntervalNew(index0.longValue(), index1.longValue())
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
 }

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
@@ -33,5 +33,10 @@ final class Native {
     public final native Result<RPtr> baseAddressPaymentCred(RPtr baseAddress);
     public final native Result<RPtr> baseAddressStakeCred(RPtr baseAddress);
 
+    // UnitInterval
+    public final native Result<byte[]> unitIntervalToBytes(RPtr unitInterval);
+    public final native Result<RPtr> unitIntervalFromBytes(byte[] bytes);
+    public final native Result<RPtr> unitIntervalNew(long index0, long index1);
+
     public final native void ptrFree(RPtr ptr);
 }

--- a/example/App.js
+++ b/example/App.js
@@ -11,9 +11,11 @@
 import React, {Component} from 'react'
 import {StyleSheet, Text, View} from 'react-native'
 import {
+  Address,
   AddrKeyHash,
   BaseAddress,
   StakeCredential,
+  UnitInterval,
 } from 'react-native-haskell-shelley'
 
 const assert = (value: any, message: string, ...args: any) => {
@@ -30,10 +32,22 @@ export default class App extends Component<{}> {
     message: '--',
   }
   async componentDidMount() {
-    const addr =
-      '0000b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b51'
+    const addr = '0000b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbf' // 28B
     const addrBytes = Buffer.from(addr, 'hex')
     try {
+      // ------------------ Address -----------------------
+      // TODO: throws rust type error
+      // const addr2 = '0100b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbf' // 28B
+      // const addrBytes2 = Buffer.from(addr2, 'hex')
+      // const addrGeneric = await Address.from_bytes(addrBytes2)
+      // console.log(addrGeneric)
+      // const addrGenericToBytes = await addrGeneric.to_bytes()
+      // console.log(Buffer.from(addrGenericToBytes).toString('hex'))
+      // assert(
+      //   Buffer.from(addrGenericToBytes).toString('hex') === addr2,
+      //   'Address.to_bytes should match original input address',
+      // )
+
       // ------------------ AddrKeyHash -----------------------
       const addrKeyHash = await AddrKeyHash.from_bytes(addrBytes)
       console.log(addrKeyHash)
@@ -59,7 +73,7 @@ export default class App extends Component<{}> {
 
       // ------------------- BaseAddress ---------------------
       const pymntAddr =
-        '0000b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b52'
+        '0000b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41c0a' // 28B
       const pymntAddrKeyHash = await AddrKeyHash.from_bytes(
         Buffer.from(pymntAddr, 'hex'),
       )
@@ -74,18 +88,26 @@ export default class App extends Component<{}> {
         'BaseAddress:: -> payment_cred -> keyhash should match original input',
       )
 
-      /* eslint-disable-next-line react/no-did-mount-set-state */
-      this.setState({
-        status: 'tests finished',
-      })
+      // ------------------- UnitInterval ---------------------
+      const unitInterval = await UnitInterval.new(0, 1)
+      console.log(await unitInterval.to_bytes())
 
       console.log('addrKeyHash', addrKeyHash)
       console.log('pymntAddrKeyHash', pymntAddrKeyHash)
       console.log('paymentCred', paymentCred)
       console.log('stakeCred', stakeCred)
       console.log('baseAddr', baseAddr)
+
+      /* eslint-disable-next-line react/no-did-mount-set-state */
+      this.setState({
+        status: 'tests finished',
+      })
     } catch (e) {
       console.log(e)
+      /* eslint-disable-next-line react/no-did-mount-set-state */
+      this.setState({
+        status: e.message,
+      })
     }
   }
   render() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,3 +76,23 @@ export class BaseAddress extends Ptr {
   */
   stake_cred(): Promise<StakeCredential>
 }
+
+export class UnitInterval extends Ptr {
+  /**
+  * @param {Uint8Array} bytes
+  * @returns {Promise<UnitInterval>}
+  */
+  static from_bytes(bytes: Uint8Array): Promise<UnitInterval>;
+
+  /**
+  * @returns {Promise<Uint8Array>}
+  */
+  to_bytes(): Promise<Uint8Array>;
+
+  /**
+  * @param {number} index0
+  * @param {number} index1
+  * @returns {Promise<UnitInterval>}
+  */
+  static new(index0, index1): Promise<UnitInterval>
+}

--- a/index.js
+++ b/index.js
@@ -150,3 +150,33 @@ export class BaseAddress extends Ptr {
       return Ptr._wrap(ret, StakeCredential);
   }
 }
+
+export class UnitInterval extends Ptr {
+  /**
+  * @param {Uint8Array} bytes
+  * @returns {Promise<UnitInterval>}
+  */
+  static async from_bytes(bytes) {
+    const ret = await HaskellShelley.unitIntervalFromBytes(b64FromUint8Array(bytes));
+    return Ptr._wrap(ret, UnitInterval);
+  }
+
+  /**
+  * @returns {Promise<Uint8Array>}
+  */
+  async to_bytes() {
+    const b64 = await HaskellShelley.unitIntervalToBytes(this.ptr);
+    return Uint8ArrayFromB64(b64);
+  }
+
+  /**
+  * @param {number} index0
+  * @param {number} index1
+  * @returns {Promise<UnitInterval>}
+  */
+  static async new(index0, index1) {
+    const ret = await HaskellShelley.unitIntervalNew(index0, index1);
+    return Ptr._wrap(ret, UnitInterval);
+  }
+
+}

--- a/ios/HaskellShelley.m
+++ b/ios/HaskellShelley.m
@@ -129,6 +129,42 @@ RCT_EXPORT_METHOD(baseAddressStakeCred:(nonnull NSString *)ptr  withResolve:(RCT
     }] exec:ptr andResolve:resolve orReject:reject];
 }
 
+// UnitInterval
+
+RCT_EXPORT_METHOD(unitIntervalToBytes:(nonnull NSString *)unitIntervalPtr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* unitIntervalPtr, CharPtr* error) {
+        DataPtr result;
+        RPtr unitInterval = [unitIntervalPtr rPtr];
+        return unit_interval_to_bytes(unitInterval, &result, error)
+            ? [[NSData fromDataPtr:&result] base64]
+            : nil;
+    }] exec:unitIntervalPtr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(unitIntervalFromBytes:(nonnull NSString *)bytesStr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* bytesStr, CharPtr* error) {
+        RPtr result;
+        NSData* data = [NSData fromBase64:bytesStr];
+        return unit_interval_from_bytes((uint8_t*)data.bytes, data.length, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:bytesStr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(unitIntervalNew:(nonnull NSNumber *)index0 withIndex1:(nonnull NSNumber *)index1 withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSArray* params, CharPtr* error) {
+        RPtr result;
+        uint64_t index0 = [[params objectAtIndex:0] unsignedLongLongValue];
+        uint64_t index1 = [[params objectAtIndex:0] unsignedLongLongValue];
+        return unit_interval_new(index0, index1, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:@[index0, index1] andResolve:resolve orReject:reject];
+}
+
 + (void)initialize
 {
     if (self == [HaskellShelley class]) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,7 +138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cddl-lib"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,7 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "cardano-legacy-address 0.1.1 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
 ]
@@ -234,7 +234,7 @@ dependencies = [
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -423,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 
 [[package]]
 name = "itoa"
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 
 [[package]]
 name = "strsim"
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#d3c65634523682f46c5a7163a614766a3fa4c219"
 
 [[package]]
 name = "typenum"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cardano-legacy-address"
 version = "0.1.1"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
  "cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,12 +138,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cddl-lib"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
- "chain-impl-mockchain 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "chain-impl-mockchain 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,19 +165,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "chain-addr"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
- "chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "cryptoxide 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chain-core"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -184,7 +185,7 @@ dependencies = [
 [[package]]
 name = "chain-crypto"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -197,43 +198,43 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "typed-bytes 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "typed-bytes 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
 ]
 
 [[package]]
 name = "chain-impl-mockchain"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
- "cardano-legacy-address 0.1.1 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "cardano-legacy-address 0.1.1 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain-addr 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
- "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
- "chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
- "chain-storage 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
- "chain-time 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "chain-addr 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "chain-storage 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
+ "chain-time 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "custom_error 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "imhamt 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "imhamt 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sparse-array 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "sparse-array 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "typed-bytes 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "typed-bytes 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
 ]
 
 [[package]]
 name = "chain-storage"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
- "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
 ]
 
 [[package]]
 name = "chain-time"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -422,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "imhamt"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 
 [[package]]
 name = "itoa"
@@ -610,7 +611,7 @@ name = "react-native-haskell-shelley"
 version = "0.0.1"
 dependencies = [
  "cbindgen 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cddl-lib 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)",
+ "cddl-lib 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)",
  "jni 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.63 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -688,7 +689,7 @@ dependencies = [
 [[package]]
 name = "sparse-array"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 
 [[package]]
 name = "strsim"
@@ -768,7 +769,7 @@ dependencies = [
 [[package]]
 name = "typed-bytes"
 version = "0.1.0"
-source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign#cfe48c67d0c42a68e3066632eeb8f95f92f0afb8"
+source = "git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen#9a7904e80f75a9b49dbfa2adb08eb3bb1e86e0b3"
 
 [[package]]
 name = "typenum"
@@ -931,19 +932,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bumpalo 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum cardano-legacy-address 0.1.1 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
+"checksum cardano-legacy-address 0.1.1 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
 "checksum cbindgen 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "104ca409bbff8293739438c71820a2606111b5f8f81835536dc673dfd807369e"
 "checksum cbor_event 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b6cda8a789815488ee290d106bc97dba47785dae73d63576fc42c126912a451"
 "checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
-"checksum cddl-lib 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
+"checksum cddl-lib 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chain-addr 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
-"checksum chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
-"checksum chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
-"checksum chain-impl-mockchain 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
-"checksum chain-storage 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
-"checksum chain-time 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
+"checksum chain-addr 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
+"checksum chain-core 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
+"checksum chain-crypto 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
+"checksum chain-impl-mockchain 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
+"checksum chain-storage 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
+"checksum chain-time 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -967,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-"checksum imhamt 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
+"checksum imhamt 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum jni 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e00f1fd30a82a801f8bf38bcb0895088a0013cde111acb713c0824edc372aa4"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
@@ -1001,7 +1002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)" = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 "checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 "checksum sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-"checksum sparse-array 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
+"checksum sparse-array 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
@@ -1011,7 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum typed-bytes 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=tx-sign)" = "<none>"
+"checksum typed-bytes 0.1.0 (git+https://github.com/Emurgo/cardano-serialization-lib.git?branch=wasm-friendly-regen)" = "<none>"
 "checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 cbindgen = "0.14.1"
 
 [dependencies]
-cddl-lib = { git = "https://github.com/Emurgo/cardano-serialization-lib.git", branch = "tx-sign", default-features = false }
+cddl-lib = { git = "https://github.com/Emurgo/cardano-serialization-lib.git", branch = "wasm-friendly-regen", default-features = false }
 wasm-bindgen = { version = "0.2" }
 
 [target.'cfg(target_os="android")'.dependencies]

--- a/rust/src/android/address.rs
+++ b/rust/src/android/address.rs
@@ -6,6 +6,7 @@ use jni::objects::{JObject};
 use jni::sys::{jbyteArray, jobject};
 use jni::JNIEnv;
 use cddl_lib::address::{Address};
+use cddl_lib::prelude::*;
 
 // cddl_lib: (&self) -> Vec<u8>
 // from react-native-chain-libs address.as_bytes (&self) -> Vec<u8>
@@ -36,8 +37,10 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_addressFromBytes
     env
       .convert_byte_array(bytes)
       .into_result()
-      .and_then(|bytes| Address::from_bytes(bytes).into_result())
-      .and_then(|address| address.rptr().jptr(&env))
+      //TODO: fix
+      // .and_then(|bytes| Address::from_bytes(bytes).into_result())
+      .and_then(|bytes| FromBytes::from_bytes(&bytes).into_result())
+      .and_then(|address: Address| address.rptr().jptr(&env))
   })
   .jresult(&env)
 }

--- a/rust/src/android/base_address.rs
+++ b/rust/src/android/base_address.rs
@@ -2,7 +2,7 @@ use super::primitive::ToPrimitiveObject;
 use super::ptr_j::*;
 use super::result::ToJniResult;
 // use super::string::ToJniString;
-use crate::panic::{handle_exception_result};
+use crate::panic::{handle_exception_result, Zip};
 use crate::ptr::RPtrRepresentable;
 use jni::objects::JObject;
 use jni::sys::{jobject, jint};
@@ -14,10 +14,19 @@ use cddl_lib::address::{BaseAddress, StakeCredential};
 pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_baseAddressNew(
   env: JNIEnv, _: JObject, network: jint, payment: JRPtr, stake: JRPtr
 ) -> jobject {
-  let payment = payment.owned::<StakeCredential>(&env);
-  let stake = stake.owned::<StakeCredential>(&env);
+  // let payment = payment.owned::<StakeCredential>(&env);
+  // let stake = stake.owned::<StakeCredential>(&env);
+  // handle_exception_result(|| {
+  //   BaseAddress::new(network as u8, payment?, stake?).rptr().jptr(&env)
+  // })
   handle_exception_result(|| {
-    BaseAddress::new(network as u8, payment?, stake?).rptr().jptr(&env)
+    let payment = payment.rptr(&env)?;
+    let stake = stake.rptr(&env)?;
+    payment.typed_ref::<StakeCredential>().zip(stake.typed_ref::<StakeCredential>()).and_then(
+      |(payment, stake)| {
+        BaseAddress::new(network as u8, payment, stake).rptr().jptr(&env)
+      }
+    )
   })
   .jresult(&env)
 }

--- a/rust/src/android/base_address.rs
+++ b/rust/src/android/base_address.rs
@@ -1,7 +1,6 @@
 use super::primitive::ToPrimitiveObject;
 use super::ptr_j::*;
 use super::result::ToJniResult;
-// use super::string::ToJniString;
 use crate::panic::{handle_exception_result, Zip};
 use crate::ptr::RPtrRepresentable;
 use jni::objects::JObject;
@@ -14,11 +13,6 @@ use cddl_lib::address::{BaseAddress, StakeCredential};
 pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_baseAddressNew(
   env: JNIEnv, _: JObject, network: jint, payment: JRPtr, stake: JRPtr
 ) -> jobject {
-  // let payment = payment.owned::<StakeCredential>(&env);
-  // let stake = stake.owned::<StakeCredential>(&env);
-  // handle_exception_result(|| {
-  //   BaseAddress::new(network as u8, payment?, stake?).rptr().jptr(&env)
-  // })
   handle_exception_result(|| {
     let payment = payment.rptr(&env)?;
     let stake = stake.rptr(&env)?;

--- a/rust/src/android/mod.rs
+++ b/rust/src/android/mod.rs
@@ -6,6 +6,7 @@ mod string;
 mod addr_key_hash;
 mod stake_credential;
 mod base_address;
+mod unit_interval;
 // declare other modules here
 // mod transaction;
 

--- a/rust/src/android/stake_credential.rs
+++ b/rust/src/android/stake_credential.rs
@@ -16,9 +16,11 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_stakeCredentialF
   env: JNIEnv, _: JObject, key_hash_ptr: JRPtr
 ) -> jobject {
   handle_exception_result(|| {
-    let key_hash = key_hash_ptr.owned::<AddrKeyHash>(&env)?;
-    let stake_credential = StakeCredential::from_keyhash(key_hash);
-    stake_credential.rptr().jptr(&env)
+    let key_hash = key_hash_ptr.rptr(&env)?;
+    key_hash
+      .typed_ref::<AddrKeyHash>()
+      .map(|key_hash| StakeCredential::from_keyhash(key_hash))
+      .and_then(|stake_credential| stake_credential.rptr().jptr(&env))
   })
   .jresult(&env)
 }

--- a/rust/src/android/stake_credential.rs
+++ b/rust/src/android/stake_credential.rs
@@ -1,7 +1,6 @@
 use super::primitive::ToPrimitiveObject;
 use super::ptr_j::*;
 use super::result::ToJniResult;
-// use super::string::ToJniString;
 use crate::panic::{handle_exception_result};
 use crate::ptr::RPtrRepresentable;
 use jni::objects::JObject;
@@ -48,7 +47,6 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_stakeCredentialK
       .typed_ref::<StakeCredential>()
       .map(|credential| credential.kind())
       .and_then(|kind| (kind as jint).jobject(&env))
-      // .and_then(|kind| kind.into_jlong().jobject(&env))
   })
   .jresult(&env)
 }

--- a/rust/src/android/unit_interval.rs
+++ b/rust/src/android/unit_interval.rs
@@ -1,0 +1,50 @@
+use super::ptr_j::*;
+use super::result::ToJniResult;
+use crate::panic::{handle_exception_result, ToResult};
+use crate::ptr::RPtrRepresentable;
+use jni::objects::{JObject};
+use jni::sys::{jbyteArray, jobject};
+use jni::JNIEnv;
+use cddl_lib::{UnitInterval};
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_unitIntervalToBytes(
+  env: JNIEnv, _: JObject, unit_interval: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let unit_interval = unit_interval.rptr(&env)?;
+    unit_interval
+      .typed_ref::<UnitInterval>()
+      .map(|unit_interval| unit_interval.to_bytes())
+      .and_then(|bytes| env.byte_array_from_slice(&bytes).into_result())
+      .map(|arr| JObject::from(arr))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_unitIntervalFromBytes(
+  env: JNIEnv, _: JObject, bytes: jbyteArray
+) -> jobject {
+  handle_exception_result(|| {
+    env
+      .convert_byte_array(bytes)
+      .into_result()
+      .and_then(|bytes| UnitInterval::from_bytes(bytes).into_result())
+      .and_then(|unit_interval| unit_interval.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_unitIntervalNew(
+  env: JNIEnv, _: JObject, index_0: jint, index_1: jint
+) -> jobject {
+  handle_exception_result(|| {
+    UnitInterval::new(index_0 as u32, index_1 as u32).rptr().jptr(&env)
+  })
+  .jresult(&env)
+}

--- a/rust/src/android/unit_interval.rs
+++ b/rust/src/android/unit_interval.rs
@@ -3,7 +3,7 @@ use super::result::ToJniResult;
 use crate::panic::{handle_exception_result, ToResult};
 use crate::ptr::RPtrRepresentable;
 use jni::objects::{JObject};
-use jni::sys::{jbyteArray, jobject};
+use jni::sys::{jbyteArray, jobject, jlong};
 use jni::JNIEnv;
 use cddl_lib::{UnitInterval};
 
@@ -41,10 +41,10 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_unitIntervalFrom
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_unitIntervalNew(
-  env: JNIEnv, _: JObject, index_0: jint, index_1: jint
+  env: JNIEnv, _: JObject, index_0: jlong, index_1: jlong
 ) -> jobject {
   handle_exception_result(|| {
-    UnitInterval::new(index_0 as u32, index_1 as u32).rptr().jptr(&env)
+    UnitInterval::new(u64::from_jlong(index_0), u64::from_jlong(index_1)).rptr().jptr(&env)
   })
   .jresult(&env)
 }

--- a/rust/src/ios/addr_key_hash.rs
+++ b/rust/src/ios/addr_key_hash.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn addr_key_hash_to_bytes(
   .response(result, error)
 }
 
-// cddl_lib: Address.from_bytes(Vec<u8>) -> Result<Address, JsValue>
+// cddl_lib: from_bytes(bytes: Vec<u8>) -> Result<$name, JsValue>
 // from react-native-chain-libs address.from_bytes(&[u8]) -> Result<Address, JsValue>
 #[no_mangle]
 pub unsafe extern "C" fn addr_key_hash_from_bytes(

--- a/rust/src/ios/address.rs
+++ b/rust/src/ios/address.rs
@@ -3,7 +3,7 @@
 
 use super::data::DataPtr;
 use super::result::CResult;
-use super::string::{CharPtr, IntoStr};
+use super::string::{CharPtr};
 use crate::panic::{handle_exception_result, ToResult};
 use crate::ptr::{RPtr, RPtrRepresentable};
 use cddl_lib::address::{Address};

--- a/rust/src/ios/base_address.rs
+++ b/rust/src/ios/base_address.rs
@@ -1,10 +1,8 @@
-use super::data::DataPtr;
 use super::result::CResult;
-use super::string::{CharPtr, IntoCString, IntoStr};
-use crate::panic::{handle_exception_result, ToResult, Zip};
+use super::string::{CharPtr};
+use crate::panic::{handle_exception_result, Zip};
 use crate::ptr::{RPtr, RPtrRepresentable};
 use cddl_lib::address::{BaseAddress, StakeCredential};
-use cddl_lib::crypto::{AddrKeyHash};
 
 #[no_mangle]
 pub unsafe extern "C" fn base_address_new(
@@ -13,10 +11,8 @@ pub unsafe extern "C" fn base_address_new(
   handle_exception_result(|| {
     payment
       .typed_ref::<StakeCredential>()
-      // .owned::<StakeCredential>()
       .zip(
         stake.typed_ref::<StakeCredential>()
-        // stake.owned::<StakeCredential>()
       )
       .map(|(payment, stake)| {
         BaseAddress::new(network, payment, stake)

--- a/rust/src/ios/base_address.rs
+++ b/rust/src/ios/base_address.rs
@@ -12,11 +12,11 @@ pub unsafe extern "C" fn base_address_new(
 ) -> bool {
   handle_exception_result(|| {
     payment
-      // .typed_ref::<StakeCredential>()
-      .owned::<StakeCredential>()
+      .typed_ref::<StakeCredential>()
+      // .owned::<StakeCredential>()
       .zip(
-        // stake.typed_ref::<StakeCredential>()
-        stake.owned::<StakeCredential>()
+        stake.typed_ref::<StakeCredential>()
+        // stake.owned::<StakeCredential>()
       )
       .map(|(payment, stake)| {
         BaseAddress::new(network, payment, stake)

--- a/rust/src/ios/mod.rs
+++ b/rust/src/ios/mod.rs
@@ -6,6 +6,7 @@ mod string;
 mod addr_key_hash;
 mod stake_credential;
 mod base_address;
+mod unit_interval;
 // declare other modules here
 // mod transaction;
 

--- a/rust/src/ios/stake_credential.rs
+++ b/rust/src/ios/stake_credential.rs
@@ -11,11 +11,10 @@ pub unsafe extern "C" fn stake_credential_from_keyhash(
   keyhash: RPtr, result: &mut RPtr, error: &mut CharPtr
 ) -> bool {
   handle_exception_result(|| {
-    // let keyhash = keyhash.owned::<AddrKeyHash>(&env)?;
-    keyhash.owned::<AddrKeyHash>()
+    keyhash
+      // .owned::<AddrKeyHash>()
+      .typed_ref::<AddrKeyHash>()
       .map(|keyhash| StakeCredential::from_keyhash(keyhash))
-    // let stake_credential = StakeCredential::from_keyhash(keyhash)
-    // .map(|keyhash| StakeCredential::from_keyhash(keyhash))
   })
     .map(|stake_credential| stake_credential.rptr())
     .response(result, error)

--- a/rust/src/ios/stake_credential.rs
+++ b/rust/src/ios/stake_credential.rs
@@ -1,7 +1,6 @@
-use super::data::DataPtr;
 use super::result::CResult;
-use super::string::{CharPtr, IntoCString, IntoStr};
-use crate::panic::{handle_exception_result, ToResult, Zip};
+use super::string::{CharPtr};
+use crate::panic::{handle_exception_result};
 use crate::ptr::{RPtr, RPtrRepresentable};
 use cddl_lib::address::{StakeCredential};
 use cddl_lib::crypto::{AddrKeyHash};
@@ -12,7 +11,6 @@ pub unsafe extern "C" fn stake_credential_from_keyhash(
 ) -> bool {
   handle_exception_result(|| {
     keyhash
-      // .owned::<AddrKeyHash>()
       .typed_ref::<AddrKeyHash>()
       .map(|keyhash| StakeCredential::from_keyhash(keyhash))
   })

--- a/rust/src/ios/unit_interval.rs
+++ b/rust/src/ios/unit_interval.rs
@@ -25,11 +25,16 @@ pub unsafe extern "C" fn unit_interval_from_bytes(
   .response(result, error)
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn unit_interval_new(
-  index_0: u32, index_1: u32, result: &mut RPtr, error: &mut CharPtr
+  index_0: u64, index_1: u64, result: &mut RPtr, error: &mut CharPtr
 ) -> bool {
   handle_exception_result(|| {
-    UnitInterval::new(index_0, index_1)
+    // TODO: test conversion. Maybe better to convert here?
+    // let idx0_u64 = u64::try_from(index0).map_err(|err| err.to_string())?;
+    // let idx1_u64 = u64::try_from(index1).map_err(|err| err.to_string())?;
+    // UnitInterval::new(idx0_u64, idx1_u64)
+    Ok(UnitInterval::new(index_0, index_1))
   })
     .map(|unit_interval| unit_interval.rptr())
     .response(result, error)

--- a/rust/src/ios/unit_interval.rs
+++ b/rust/src/ios/unit_interval.rs
@@ -1,0 +1,36 @@
+use super::data::DataPtr;
+use super::result::CResult;
+use super::string::{CharPtr};
+use crate::panic::{handle_exception_result, ToResult};
+use crate::ptr::{RPtr, RPtrRepresentable};
+use cddl_lib::{UnitInterval};
+
+#[no_mangle]
+pub unsafe extern "C" fn unit_interval_to_bytes(
+  unit_interval: RPtr, result: &mut DataPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| unit_interval.typed_ref::<UnitInterval>().map(|unit_interval| unit_interval.to_bytes()))
+  .map(|bytes| bytes.into())
+  .response(result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn unit_interval_from_bytes(
+  data: *const u8, len: usize, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    UnitInterval::from_bytes(std::slice::from_raw_parts(data, len).into()).into_result()
+  })
+  .map(|unit_interval| unit_interval.rptr())
+  .response(result, error)
+}
+
+pub unsafe extern "C" fn unit_interval_new(
+  index_0: u32, index_1: u32, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    UnitInterval::new(index_0, index_1)
+  })
+    .map(|unit_interval| unit_interval.rptr())
+    .response(result, error)
+}

--- a/rust/src/js_result.rs
+++ b/rust/src/js_result.rs
@@ -1,8 +1,15 @@
 use crate::panic::{Result, ToResult};
 use wasm_bindgen::JsValue;
+use cddl_lib::prelude::{DeserializeError};
 
 impl<T> ToResult<T> for std::result::Result<T, JsValue> {
   fn into_result(self) -> Result<T> {
     self.map_err(|jsval| format!("{:?}", jsval))
+  }
+}
+
+impl<T> ToResult<T> for std::result::Result<T, DeserializeError> {
+  fn into_result(self) -> Result<T> {
+    self.map_err(|e| e.to_string())
   }
 }

--- a/rust/src/ptr_impl.rs
+++ b/rust/src/ptr_impl.rs
@@ -1,8 +1,10 @@
 use crate::ptr::RPtrRepresentable;
 use cddl_lib::address::*;
 use cddl_lib::crypto::*;
+use cddl_lib::{UnitInterval};
 
 impl RPtrRepresentable for Address {}
 impl RPtrRepresentable for AddrKeyHash {}
 impl RPtrRepresentable for BaseAddress {}
 impl RPtrRepresentable for StakeCredential {}
+impl RPtrRepresentable for UnitInterval {}


### PR DESCRIPTION
This PR just updates the initial work that's been done so far to use the new API defined in `cddl-bindgen`. Also adds `UnitInterval` (which was mostly an experiment to play with `u64`s.) and does a little clean up.