### PR TITLE
add bindings required for ledger support part 2

### DIFF
--- a/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
@@ -457,9 +457,25 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public final void stakeCredentialFromScriptHash(String scriptHash, Promise promise) {
+        Native.I
+                .stakeCredentialFromScriptHash(new RPtr(scriptHash))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
     public final void stakeCredentialToKeyHash(String stakeCredential, Promise promise) {
         Native.I
                 .stakeCredentialToKeyHash(new RPtr(stakeCredential))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void stakeCredentialToScriptHash(String stakeCredential, Promise promise) {
+        Native.I
+                .stakeCredentialToScriptHash(new RPtr(stakeCredential))
                 .map(RPtr::toJs)
                 .pour(promise);
     }

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
@@ -410,6 +410,24 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
                 .pour(promise);
     }
 
+    // ScriptHash
+
+    @ReactMethod
+    public final void scriptHashToBytes(String scriptHash, Promise promise) {
+        Native.I
+                .scriptHashToBytes(new RPtr(scriptHash))
+                .map(bytes -> Base64.encodeToString(bytes, Base64.DEFAULT))
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void scriptHashFromBytes(String bytes, Promise promise) {
+        Native.I
+                .scriptHashFromBytes(Base64.decode(bytes, Base64.DEFAULT))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
     // TransactionHash
 
     @ReactMethod

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
@@ -327,6 +327,14 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public final void byronAddressByronProtocolMagic(String byronAddress, Promise promise) {
+        Native.I
+                .byronAddressByronProtocolMagic(new RPtr(byronAddress))
+                .map(Long::intValue)
+                .pour(promise);
+    }
+
+    @ReactMethod
     public final void byronAddressAttributes(String byronAddress, Promise promise) {
         Native.I
                 .byronAddressAttributes(new RPtr(byronAddress))
@@ -371,6 +379,13 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
         Native.I
                 .addressFromBech32(string)
                 .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void addressNetworkId(String address, Promise promise) {
+        Native.I
+                .addressNetworkId(new RPtr(address))
                 .pour(promise);
     }
 

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
@@ -606,6 +606,30 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public final void certificateAsStakeRegistration(String certificate, Promise promise) {
+        Native.I
+                .certificateAsStakeRegistration(new RPtr(certificate))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void certificateAsStakeDeregistration(String certificate, Promise promise) {
+        Native.I
+                .certificateAsStakeDeregistration(new RPtr(certificate))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void certificateAsStakeDelegation(String certificate, Promise promise) {
+        Native.I
+                .certificateAsStakeDelegation(new RPtr(certificate))
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
     public final void certificateToBytes(String certificate, Promise promise) {
         Native.I
                 .certificateToBytes(new RPtr(certificate))

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/HaskellShelleyModule.java
@@ -796,6 +796,39 @@ public class HaskellShelleyModule extends ReactContextBaseJavaModule {
                 .pour(promise);
     }
 
+    // RewardAddresses
+
+    @ReactMethod
+    public final void rewardAddressesNew(Promise promise) {
+        Native.I
+                .rewardAddressesNew()
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void rewardAddressesLen(String rewardAddresses, Promise promise) {
+        Native.I
+                .rewardAddressesLen(new RPtr(rewardAddresses))
+                .map(Long::intValue)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void rewardAddressesGet(String rewardAddresses, Integer index, Promise promise) {
+        Native.I
+                .rewardAddressesGet(new RPtr(rewardAddresses), index)
+                .map(RPtr::toJs)
+                .pour(promise);
+    }
+
+    @ReactMethod
+    public final void rewardAddressesAdd(String rewardAddresses, String item, Promise promise) {
+        Native.I
+                .rewardAddressesAdd(new RPtr(rewardAddresses), new RPtr(item))
+                .pour(promise);
+    }
+
     // UnitInterval
 
     @ReactMethod

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
@@ -149,6 +149,12 @@ final class Native {
     public final native Result<RPtr> rewardAddressToAddress(RPtr baseAddress);
     public final native Result<RPtr> rewardAddressFromAddress(RPtr address);
 
+    // RewardAddresses
+    public final native Result<RPtr> rewardAddressesNew();
+    public final native Result<Long> rewardAddressesLen(RPtr rewardAddresses);
+    public final native Result<RPtr> rewardAddressesGet(RPtr rewardAddresses, long index);
+    public final native Result<Void> rewardAddressesAdd(RPtr rewardAddresses, RPtr item);
+
     // UnitInterval
     public final native Result<byte[]> unitIntervalToBytes(RPtr unitInterval);
     public final native Result<RPtr> unitIntervalFromBytes(byte[] bytes);

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
@@ -66,6 +66,7 @@ final class Native {
     public final native Result<Boolean> byronAddressIsValid(String str);
     public final native Result<RPtr> byronAddressFromAddress(RPtr address);
     public final native Result<RPtr> byronAddressToAddress(RPtr byronAddress);
+    public final native Result<Long> byronAddressByronProtocolMagic(RPtr byronAddress);
     public final native Result<byte[]> byronAddressAttributes(RPtr byronAddress);
 
     // Address
@@ -74,6 +75,7 @@ final class Native {
     public final native Result<String> addressToBech32(RPtr address);
     public final native Result<String> addressToBech32WithPrefix(RPtr address, String prefix);
     public final native Result<RPtr> addressFromBech32(String str);
+    public final native Result<Integer> addressNetworkId(RPtr address);
 
     // Ed25519Signature
     public final native Result<byte[]> ed25519SignatureToBytes(RPtr ed25519Signature);

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
@@ -93,7 +93,9 @@ final class Native {
 
     // StakeCredential
     public final native Result<RPtr> stakeCredentialFromKeyHash(RPtr keyHash);
+    public final native Result<RPtr> stakeCredentialFromScriptHash(RPtr keyHash);
     public final native Result<RPtr> stakeCredentialToKeyHash(RPtr stakeCredential);
+    public final native Result<RPtr> stakeCredentialToScriptHash(RPtr stakeCredential);
     public final native Result<Integer> stakeCredentialKind(RPtr stakeCredential);
     public final native Result<byte[]> stakeCredentialToBytes(RPtr stakeCredential);
     public final native Result<RPtr> stakeCredentialFromBytes(byte[] bytes);

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
@@ -117,6 +117,9 @@ final class Native {
     public final native Result<RPtr> certificateNewStakeRegistration(RPtr stakeRegistration);
     public final native Result<RPtr> certificateNewStakeDeregistration(RPtr stakeDeregistration);
     public final native Result<RPtr> certificateNewStakeDelegation(RPtr stakeDelegation);
+    public final native Result<RPtr> certificateAsStakeRegistration(RPtr certificate);
+    public final native Result<RPtr> certificateAsStakeDeregistration(RPtr certificate);
+    public final native Result<RPtr> certificateAsStakeDelegation(RPtr certificate);
     public final native Result<byte[]> certificateToBytes(RPtr certificate);
     public final native Result<RPtr> certificateFromBytes(byte[] bytes);
 

--- a/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
+++ b/android/src/main/java/io/emurgo/rnhaskellshelley/Native.java
@@ -83,6 +83,10 @@ final class Native {
     public final native Result<byte[]> ed25519KeyHashToBytes(RPtr ed25519KeyHash);
     public final native Result<RPtr> ed25519KeyHashFromBytes(byte[] bytes);
 
+    // ScriptHash
+    public final native Result<byte[]> scriptHashToBytes(RPtr scriptHash);
+    public final native Result<RPtr> scriptHashFromBytes(byte[] bytes);
+
     // TransactionHash
     public final native Result<byte[]> transactionHashToBytes(RPtr transactionHash);
     public final native Result<RPtr> transactionHashFromBytes(byte[] bytes);

--- a/example/App.js
+++ b/example/App.js
@@ -179,6 +179,7 @@ export default class App extends Component<{}> {
           'addr1qyfh4879pratq227f5z6qr48mvwa3acwvtyvgq5553jk8g7nsw44z0v5d2emp8unhqz5em0d7cup75vrxhlqf6l9nzfqphk420',
         'Address.to_bech32 with default prefix',
       )
+      assert((await address.network_id()) === 0, 'address.network_id()')
 
       // ------------------------------------------------
       // ----------------- ByronAddress -----------------
@@ -208,6 +209,10 @@ export default class App extends Component<{}> {
           await ByronAddress.from_address(addrFromByronAddr)
         ).to_base58()) === addrBase58,
         'ByronAddress.to_address',
+      )
+      assert(
+        (await byronAddress.byron_protocol_magic()) === 764824073,
+        'ByronAddress.byron_protocol_magic()',
       )
       const byronAddressAttributesHex = Buffer.from(
         await byronAddress.attributes(),

--- a/example/App.js
+++ b/example/App.js
@@ -32,6 +32,7 @@ import {
   PublicKey,
   RewardAddress,
   RewardAddresses,
+  ScriptHash,
   StakeCredential,
   StakeDelegation,
   StakeDeregistration,
@@ -233,13 +234,23 @@ export default class App extends Component<{}> {
 
       // ------------------------------------------------
       // ---------------- Ed25519KeyHash ----------------
-      const addrHex = '0000b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbf' // 28B
-      const addrBytes = Buffer.from(addrHex, 'hex')
-      const ed25519KeyHash = await Ed25519KeyHash.from_bytes(addrBytes)
-      const addrToBytes = await ed25519KeyHash.to_bytes()
+      const keyHashHex =
+        '0000b03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbf' // 28B
+      const keyHashBytes = Buffer.from(keyHashHex, 'hex')
+      const ed25519KeyHash = await Ed25519KeyHash.from_bytes(keyHashBytes)
+      const ed25519KeyHashToBytes = await ed25519KeyHash.to_bytes()
       assert(
-        Buffer.from(addrToBytes).toString('hex') === addrHex,
+        Buffer.from(ed25519KeyHashToBytes).toString('hex') === keyHashHex,
         'Ed25519KeyHash.to_bytes should match original input address',
+      )
+
+      // ------------------------------------------------
+      // ------------------- ScriptHash -----------------
+      const scriptHash = await ScriptHash.from_bytes(keyHashBytes)
+      const scriptHashToBytes = await scriptHash.to_bytes()
+      assert(
+        Buffer.from(scriptHashToBytes).toString('hex') === keyHashHex,
+        'ScriptHash.to_bytes should match original input address',
       )
 
       // ------------------------------------------------
@@ -264,7 +275,7 @@ export default class App extends Component<{}> {
       )
       assert(
         Buffer.from(await ed25519KeyHashOrig.to_bytes()).toString('hex') ===
-          addrHex,
+          keyHashHex,
         'StakeCredential:: -> to_keyhash -> to_bytes should match original input',
       )
       assert(
@@ -274,7 +285,7 @@ export default class App extends Component<{}> {
       assert(
         Buffer.from(
           await (await stakeCredFromBytes.to_keyhash()).to_bytes(),
-        ).toString('hex') === addrHex,
+        ).toString('hex') === keyHashHex,
         'StakeCredential -> to_bytes -> from_bytes -> to_keyhash -> should match',
       )
 

--- a/example/App.js
+++ b/example/App.js
@@ -369,10 +369,35 @@ export default class App extends Component<{}> {
         Buffer.from(await _cert.to_bytes(), 'hex').toString('hex') === certHex,
         'Certificate::new_stake_registration()',
       )
+      assert(
+        (await cert.as_stake_registration()) instanceof StakeRegistration,
+        'Certificate::as_stake_registration()',
+      )
+      assert(
+        (await cert.as_stake_deregistration()) == null,
+        'Certificate::as_stake_deregistration() should be null for different cert',
+      )
       const certDereg = await Certificate.new_stake_deregistration(stakeDereg)
       assert(certDereg, 'Certificate::new_stake_deregistration()')
+      assert(
+        (await certDereg.as_stake_deregistration()) instanceof
+          StakeDeregistration,
+        'Certificate::as_stake_deregistration()',
+      )
+      assert(
+        (await certDereg.as_stake_delegation()) == null,
+        'Certificate::as_stake_delegation() should be null for different cert',
+      )
       const certDel = await Certificate.new_stake_delegation(stakeDelegation)
       assert(certDel, 'Certificate::new_stake_delegation()')
+      assert(
+        (await certDel.as_stake_delegation()) instanceof StakeDelegation,
+        'Certificate::as_stake_delegation()',
+      )
+      assert(
+        (await certDel.as_stake_registration()) == null,
+        'Certificate::as_stake_registration() should be null for different cert',
+      )
 
       // ------------------------------------------------
       // ----------------- Certificates -----------------

--- a/example/App.js
+++ b/example/App.js
@@ -496,6 +496,20 @@ export default class App extends Component<{}> {
       )
 
       // ------------------------------------------------
+      // ----------------- RewardAddresses ------------------
+      const rewardAddresses = await RewardAddresses.new()
+      assert(
+        rewardAddresses instanceof RewardAddresses,
+        'RewardAddresses::new()',
+      )
+      await rewardAddresses.add(rewardAddr)
+      assert((await rewardAddresses.len()) === 1, 'RewardAddresses::len()')
+      assert(
+        (await rewardAddresses.get(0)) instanceof RewardAddress,
+        'RewardAddresses::get()',
+      )
+
+      // ------------------------------------------------
       // ------------------ UnitInterval ----------------
       const numeratorStr = '1000000'
       const denominatorStr = '1000000'

--- a/example/App.js
+++ b/example/App.js
@@ -288,6 +288,23 @@ export default class App extends Component<{}> {
         ).toString('hex') === keyHashHex,
         'StakeCredential -> to_bytes -> from_bytes -> to_keyhash -> should match',
       )
+      assert(
+        (await stakeCred.to_scripthash()) == null,
+        'StakeCredential::to_scripthash should be null for Ed25519KeyHash',
+      )
+      const stakeCredFromScriptHash = await StakeCredential.from_scripthash(
+        scriptHash,
+      )
+      assert(
+        (await stakeCredFromScriptHash.to_keyhash()) == null,
+        'StakeCredential::to_keyhash should be null for ScriptHash',
+      )
+      assert(
+        Buffer.from(
+          await (await stakeCredFromScriptHash.to_scripthash()).to_bytes(),
+        ).toString('hex') === keyHashHex,
+        'StakeCredential::to_scripthash',
+      )
 
       // ------------------------------------------------
       // --------------- StakeRegistration --------------
@@ -879,6 +896,7 @@ export default class App extends Component<{}> {
       console.log('address', address)
       console.log('ed25519Signature', ed25519Signature)
       console.log('ed25519KeyHash', ed25519KeyHash)
+      console.log('scriptHash', scriptHash)
       console.log('txHash', txHash)
       console.log('pymntAddrKeyHash', pymntAddrKeyHash)
       console.log('paymentCred', paymentCred)

--- a/index.d.ts
+++ b/index.d.ts
@@ -339,6 +339,20 @@ export class Ed25519KeyHash extends Ptr {
   to_bytes(): Promise<Uint8Array>;
 }
 
+export class ScriptHash extends Ptr {
+
+  /**
+  * @returns {Promise<Uint8Array>}
+  */
+  to_bytes(): Promise<Uint8Array>;
+
+  /**
+  * @param {Uint8Array} bytes
+  * @returns {Promise<ScriptHash>}
+  */
+  static from_bytes(bytes: Uint8Array): Promise<ScriptHash>;
+}
+
 export class TransactionHash extends Ptr {
   /**
   * @param {Uint8Array} bytes
@@ -373,7 +387,7 @@ export class StakeCredential extends Ptr {
   /**
   * @returns {Promise<Ed25519KeyHash>}
   */
-  to_keyhash(): Promise<Ed25519KeyHash>;
+  to_keyhash(): Promise<Ed25519KeyHash | undefined>;
 
   /**
   * @returns {Promise<number>}

--- a/index.d.ts
+++ b/index.d.ts
@@ -283,6 +283,11 @@ export class ByronAddress extends Ptr {
   static from_address(addr): Promise<ByronAddress | undefined>;
 
   /**
+  * @returns {Promise<number>}
+  */
+  byron_protocol_magic(): Promise<number>;
+
+  /**
   * @returns {Promise<Uint8Array>}
   */
   async attributes(): Promise<Uint8Array>;
@@ -311,6 +316,11 @@ export class Address extends Ptr {
   * @returns {Promise<Address>}
   */
   static from_bech32(string) : Promise<Address>
+
+  /**
+  * @returns {Promise<number>}
+  */
+  network_id(): Promise<number>;
 }
 
 export class Ed25519Signature extends Ptr {

--- a/index.d.ts
+++ b/index.d.ts
@@ -385,9 +385,20 @@ export class StakeCredential extends Ptr {
   static from_keyhash(hash: Ed25519KeyHash): Promise<StakeCredential>
 
   /**
+  * @param {ScriptHash} hash
+  * @returns {Promise<StakeCredential>}
+  */
+  static from_scripthash(hash: ScriptHash): Promise<StakeCredential>;
+
+  /**
   * @returns {Promise<Ed25519KeyHash>}
   */
   to_keyhash(): Promise<Ed25519KeyHash | undefined>;
+
+  /**
+  * @returns {Promise<ScriptHash | undefined>}
+  */
+  to_scripthash(): Promise<ScriptHash | undefined>;
 
   /**
   * @returns {Promise<number>}

--- a/index.d.ts
+++ b/index.d.ts
@@ -617,8 +617,29 @@ export class RewardAddress extends Ptr {
   static from_address(addr: Address): Promise<RewardAddress | undefined>
 }
 
-/* TODO */
-export class RewardAddresses extends Ptr {}
+export class RewardAddresses extends Ptr {
+  /**
+  * @returns {Promise<RewardAddresses>}
+  */
+  static new(): Promise<RewardAddresses>;
+
+  /**
+  * @returns {Promise<number>}
+  */
+  len(): Promise<number>;
+
+  /**
+  * @param {number} index
+  * @returns {Promise<RewardAddress>}
+  */
+  get(index: number): Promise<RewardAddress>;
+
+  /**
+  * @param {RewardAddress} item
+  * @returns {Promise<void>}
+  */
+  add(item: RewardAddress): Promise<void>;
+}
 
 export class UnitInterval extends Ptr {
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -469,25 +469,40 @@ export class Certificate extends Ptr {
   * @param {Uint8Array} bytes
   * @returns {Promise<Certificate>}
   */
-  static from_bytes(bytes): Promise<Certificate>
+  static from_bytes(bytes): Promise<Certificate>;
 
   /**
   * @param {StakeRegistration} stakeRegistration
   * @returns {Promise<Certificate>}
   */
-  static new_stake_registration(stakeRegistration): Promise<Certificate>
+  static new_stake_registration(stakeRegistration): Promise<Certificate>;
 
   /**
   * @param {StakeDeregistration} stakeDeregistration
   * @returns {Promise<Certificate>}
   */
-  static new_stake_deregistration(stakeDeregistration): Promise<Certificate>
+  static new_stake_deregistration(stakeDeregistration): Promise<Certificate>;
 
   /**
   * @param {StakeDelegation} stakeDelegation
   * @returns {Promise<Certificate>}
   */
-  static new_stake_delegation(stakeDelegation): Promise<Certificate>
+  static new_stake_delegation(stakeDelegation): Promise<Certificate>;
+
+  /**
+  * @returns {Promise<StakeRegistration | undefined>}
+  */
+  as_stake_registration(): Promise<StakeRegistration | undefined>;
+
+  /**
+  * @returns {Promise<StakeDeregistration | undefined>}
+  */
+  as_stake_deregistration(): Promise<StakeDeregistration | undefined>;
+
+  /**
+  * @returns {Promise<StakeDelegation | undefined>}
+  */
+  as_stake_delegation(): Promise<StakeDelegation | undefined>;
 }
 
 export class Certificates extends Ptr {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1007,7 +1007,7 @@ export class Withdrawals extends Ptr {
   get(key: RewardAddress): Promise<BigNum | undefined>;
 
   /**
-  * @returns {Promise<RewardAddress>}
+  * @returns {Promise<RewardAddresses>}
   */
-  keys(): Promise<RewardAddress>;
+  keys(): Promise<RewardAddresses>;
 }

--- a/index.js
+++ b/index.js
@@ -950,8 +950,40 @@ export class RewardAddress extends Ptr {
   }
 }
 
-/* TODO */
-export class RewardAddresses extends Ptr {}
+export class RewardAddresses extends Ptr {
+  /**
+  * @returns {Promise<RewardAddresses>}
+  */
+  static async new() {
+      const ret = await HaskellShelley.rewardAddressesNew();
+      return Ptr._wrap(ret, RewardAddresses);
+  }
+
+  /**
+  * @returns {Promise<number>}
+  */
+  async len() {
+    return HaskellShelley.rewardAddressesLen(this.ptr);
+  }
+
+  /**
+  * @param {number} index
+  * @returns {Promise<RewardAddress>}
+  */
+  async get(index) {
+    const ret = await HaskellShelley.rewardAddressesGet(this.ptr, index);
+    return Ptr._wrap(ret, RewardAddress);
+  }
+
+  /**
+  * @param {RewardAddress} item
+  * @returns {Promise<void>}
+  */
+  async add(item) {
+    const itemPtr = Ptr._assertClass(item, RewardAddress);
+    return HaskellShelley.rewardAddressesAdd(this.ptr, itemPtr);
+  }
+}
 
 export class UnitInterval extends Ptr {
   /**

--- a/index.js
+++ b/index.js
@@ -437,6 +437,13 @@ export class ByronAddress extends Ptr {
   }
 
   /**
+  * @returns {Promise<number>}
+  */
+  byron_protocol_magic() {
+    return HaskellShelley.byronAddressByronProtocolMagic(this.ptr);
+  }
+
+  /**
   * @returns {Promise<Uint8Array>}
   */
   async attributes() {
@@ -481,6 +488,13 @@ export class Address extends Ptr {
   static async from_bech32(string) {
     const ret = await HaskellShelley.addressFromBech32(string);
     return Ptr._wrap(ret, Address);
+  }
+
+  /**
+  * @returns {Promise<number>}
+  */
+  network_id() {
+    return HaskellShelley.addressNetworkId(this.ptr);
   }
 }
 
@@ -856,7 +870,7 @@ export class Certificates extends Ptr {
   * @param {Certificate} item
   * @returns {Promise<void>}
   */
-  async add(item) {
+  add(item) {
     const itemPtr = Ptr._assertClass(item, Certificate);
     return HaskellShelley.certificatesAdd(this.ptr, itemPtr);
   }

--- a/index.js
+++ b/index.js
@@ -523,6 +523,26 @@ export class Ed25519KeyHash extends Ptr {
   }
 }
 
+export class ScriptHash extends Ptr {
+
+  /**
+  * @returns {Promise<Uint8Array>}
+  */
+  async to_bytes() {
+    const b64 = await HaskellShelley.scriptHashToBytes(this.ptr);
+    return Uint8ArrayFromB64(b64);
+  }
+
+  /**
+  * @param {Uint8Array} bytes
+  * @returns {Promise<ScriptHash>}
+  */
+  static async from_bytes(bytes) {
+    const ret = await HaskellShelley.scriptHashFromBytes(b64FromUint8Array(bytes));
+    return Ptr._wrap(ret, ScriptHash);
+  }
+}
+
 export class TransactionHash extends Ptr {
 
   /**
@@ -558,15 +578,20 @@ export class StakeCredential extends Ptr {
   // static async from_scripthash(hash)
 
   /**
-  * @returns {Promise<Ed25519KeyHash>}
+  * @returns {Promise<Ed25519KeyHash | undefined>}
   */
   async to_keyhash() {
     const ret = await HaskellShelley.stakeCredentialToKeyHash(this.ptr);
     return Ptr._wrap(ret, Ed25519KeyHash);
   }
 
-  // TODO
-  // static async to_scripthash(hash)
+  /**
+  * @returns {Promise<ScriptHash | undefined>}
+  */
+  async to_scripthash() {
+    const ret = await HaskellShelley.stakeCredentialToScriptHash(this.ptr);
+    return Ptr._wrap(ret, ScriptHash);
+  }
 
   /**
   * @returns {Promise<number>}

--- a/index.js
+++ b/index.js
@@ -752,15 +752,39 @@ export class Certificate extends Ptr {
     return Ptr._wrap(ret, Certificate);
   }
 
-    /**
-    * @param {StakeDelegation} stakeDelegation
-    * @returns {Promise<Certificate>}
-    */
-    static async new_stake_delegation(stakeDelegation) {
-      const stakeDelegationPtr = Ptr._assertClass(stakeDelegation, StakeDelegation);
-      const ret = await HaskellShelley.certificateNewStakeDelegation(stakeDelegationPtr);
-      return Ptr._wrap(ret, Certificate);
-    }
+  /**
+  * @param {StakeDelegation} stakeDelegation
+  * @returns {Promise<Certificate>}
+  */
+  static async new_stake_delegation(stakeDelegation) {
+    const stakeDelegationPtr = Ptr._assertClass(stakeDelegation, StakeDelegation);
+    const ret = await HaskellShelley.certificateNewStakeDelegation(stakeDelegationPtr);
+    return Ptr._wrap(ret, Certificate);
+  }
+
+  /**
+  * @returns {Promise<StakeRegistration | undefined>}
+  */
+  async as_stake_registration() {
+    const ret = await HaskellShelley.certificateAsStakeRegistration(this.ptr);
+    return Ptr._wrap(ret, StakeRegistration);
+  }
+
+  /**
+  * @returns {Promise<StakeDeregistration | undefined>}
+  */
+  async as_stake_deregistration() {
+    const ret = await HaskellShelley.certificateAsStakeDeregistration(this.ptr);
+    return Ptr._wrap(ret, StakeDeregistration);
+  }
+
+  /**
+  * @returns {Promise<StakeDelegation | undefined>}
+  */
+  async as_stake_delegation() {
+    const ret = await HaskellShelley.certificateAsStakeDelegation(this.ptr);
+    return Ptr._wrap(ret, StakeDelegation);
+  }
 }
 
 export class Certificates extends Ptr {

--- a/index.js
+++ b/index.js
@@ -574,8 +574,15 @@ export class StakeCredential extends Ptr {
     return Ptr._wrap(ret, StakeCredential);
   }
 
-  // TODO
-  // static async from_scripthash(hash)
+  /**
+  * @param {ScriptHash} hash
+  * @returns {Promise<StakeCredential>}
+  */
+  static async from_scripthash(hash) {
+    const scriptHashPtr = Ptr._assertClass(hash, ScriptHash);
+    const ret = await HaskellShelley.stakeCredentialFromScriptHash(scriptHashPtr);
+    return Ptr._wrap(ret, StakeCredential);
+  }
 
   /**
   * @returns {Promise<Ed25519KeyHash | undefined>}

--- a/ios/HaskellShelley.m
+++ b/ios/HaskellShelley.m
@@ -596,12 +596,34 @@ RCT_EXPORT_METHOD(stakeCredentialFromKeyHash:(nonnull NSString *)ptr  withResolv
     }] exec:ptr andResolve:resolve orReject:reject];
 }
 
+RCT_EXPORT_METHOD(stakeCredentialFromScriptHash:(nonnull NSString *)ptr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
+        RPtr result;
+        RPtr scriptHash = [ptr rPtr];
+        return stake_credential_from_scripthash(scriptHash, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
+}
+
 RCT_EXPORT_METHOD(stakeCredentialToKeyHash:(nonnull NSString *)ptr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
 {
     [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
         RPtr result;
         RPtr stakeCredential = [ptr rPtr];
         return stake_credential_to_keyhash(stakeCredential, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(stakeCredentialToScriptHash:(nonnull NSString *)ptr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
+        RPtr result;
+        RPtr stakeCredential = [ptr rPtr];
+        return stake_credential_to_scripthash(stakeCredential, &result, error)
             ? [NSString stringFromPtr:result]
             : nil;
     }] exec:ptr andResolve:resolve orReject:reject];

--- a/ios/HaskellShelley.m
+++ b/ios/HaskellShelley.m
@@ -1065,6 +1065,51 @@ RCT_EXPORT_METHOD(rewardAddressFromAddress:(nonnull NSString *)addrPtr withResol
     }] exec:addrPtr andResolve:resolve orReject:reject];
 }
 
+// RewardAddresses
+
+RCT_EXPORT_METHOD(rewardAddressesNew:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(id _void, CharPtr* error) {
+        RPtr result;
+        return reward_addresses_new(&result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:nil andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(rewardAddressesLen:(nonnull NSString *)rewardAddressesPtr withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSNumber*(NSString* rewardAddressesPtr, CharPtr* error) {
+        uintptr_t result;
+        RPtr rewardAddresses = [rewardAddressesPtr rPtr];
+        return reward_addresses_len(rewardAddresses, &result, error)
+            ? [NSNumber numberWithUnsignedLong:result]
+            : nil;
+    }] exec:rewardAddressesPtr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(rewardAddressesGet:(nonnull NSString *)rewardAddressesPtr withIndex:(nonnull NSNumber *)index withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSArray* params, CharPtr* error) {
+        RPtr result;
+        RPtr rewardAddresses = [[params objectAtIndex:0] rPtr];
+        uintptr_t index = [[params objectAtIndex:1] unsignedIntegerValue];
+        return reward_addresses_get(rewardAddresses, index, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:@[rewardAddressesPtr, index] andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(rewardAddressesAdd:(nonnull NSString *)rewardAddressesPtr withItem:(nonnull NSString *)itemPtr withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSArray* params, CharPtr* error) {
+        RPtr rewardAddresses = [[params objectAtIndex:0] rPtr];
+        RPtr item = [[params objectAtIndex:1] rPtr];
+        reward_addresses_add(&rewardAddresses, item, error);
+        return nil;
+    }] exec:@[rewardAddressesPtr, itemPtr] andResolve:resolve orReject:reject];
+}
+
 // UnitInterval
 
 RCT_EXPORT_METHOD(unitIntervalToBytes:(nonnull NSString *)unitIntervalPtr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)

--- a/ios/HaskellShelley.m
+++ b/ios/HaskellShelley.m
@@ -535,6 +535,30 @@ RCT_EXPORT_METHOD(ed25519KeyHashFromBytes:(nonnull NSString *)bytesStr  withReso
     }] exec:bytesStr andResolve:resolve orReject:reject];
 }
 
+// ScriptHash
+
+RCT_EXPORT_METHOD(scriptHashToBytes:(nonnull NSString *)keyHashPtr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* keyHashPtr, CharPtr* error) {
+        DataPtr result;
+        RPtr keyHash = [keyHashPtr rPtr];
+        return script_hash_to_bytes(keyHash, &result, error)
+            ? [[NSData fromDataPtr:&result] base64]
+            : nil;
+    }] exec:keyHashPtr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(scriptHashFromBytes:(nonnull NSString *)bytesStr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* bytesStr, CharPtr* error) {
+        RPtr result;
+        NSData* data = [NSData fromBase64:bytesStr];
+        return script_hash_from_bytes((uint8_t*)data.bytes, data.length, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:bytesStr andResolve:resolve orReject:reject];
+}
+
 // TransactionHash
 
 RCT_EXPORT_METHOD(transactionHashToBytes:(nonnull NSString *)txHashPtr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)

--- a/ios/HaskellShelley.m
+++ b/ios/HaskellShelley.m
@@ -420,6 +420,17 @@ RCT_EXPORT_METHOD(byronAddressFromAddress:(nonnull NSString *)addrPtr withResolv
     }] exec:addrPtr andResolve:resolve orReject:reject];
 }
 
+RCT_EXPORT_METHOD(byronAddressByronProtocolMagic:(nonnull NSString *)ptr withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSNumber*(NSString* ptr, CharPtr* error) {
+        uint32_t result;
+        RPtr byronAddress = [ptr rPtr];
+        return byron_address_byron_protocol_magic(byronAddress, &result, error)
+            ? [NSNumber numberWithLong:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
+}
+
 RCT_EXPORT_METHOD(byronAddressAttributes:(nonnull NSString *)ptr withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
 {
     [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
@@ -485,6 +496,17 @@ RCT_EXPORT_METHOD(addressFromBech32:(nonnull NSString *)string withResolve:(RCTP
             ? [NSString stringFromPtr:result]
             : nil;
     }] exec:string andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(addressNetworkId:(nonnull NSString *)ptr withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSNumber*(NSString* ptr, CharPtr* error) {
+        uint8_t result;
+        RPtr address = [ptr rPtr];
+        return address_network_id(address, &result, error)
+            ? [NSNumber numberWithInt:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
 }
 
 // Ed25519Signature

--- a/ios/HaskellShelley.m
+++ b/ios/HaskellShelley.m
@@ -803,6 +803,39 @@ RCT_EXPORT_METHOD(certificateNewStakeDelegation:(nonnull NSString *)ptr  withRes
     }] exec:ptr andResolve:resolve orReject:reject];
 }
 
+RCT_EXPORT_METHOD(certificateAsStakeRegistration:(nonnull NSString *)ptr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
+        RPtr result;
+        RPtr certificate = [ptr rPtr];
+        return certificate_as_stake_registration(certificate, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(certificateAsStakeDeregistration:(nonnull NSString *)ptr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
+        RPtr result;
+        RPtr certificate = [ptr rPtr];
+        return certificate_as_stake_deregistration(certificate, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
+}
+
+RCT_EXPORT_METHOD(certificateAsStakeDelegation:(nonnull NSString *)ptr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
+{
+    [[CSafeOperation new:^NSString*(NSString* ptr, CharPtr* error) {
+        RPtr result;
+        RPtr certificate = [ptr rPtr];
+        return certificate_as_stake_delegation(certificate, &result, error)
+            ? [NSString stringFromPtr:result]
+            : nil;
+    }] exec:ptr andResolve:resolve orReject:reject];
+}
+
 RCT_EXPORT_METHOD(certificateToBytes:(nonnull NSString *)certificatePtr  withResolve:(RCTPromiseResolveBlock)resolve andReject:(RCTPromiseRejectBlock)reject)
 {
     [[CSafeOperation new:^NSString*(NSString* certificatePtr, CharPtr* error) {

--- a/rust/src/android/address.rs
+++ b/rust/src/android/address.rs
@@ -4,8 +4,9 @@ use super::string::*;
 use crate::panic::{handle_exception_result, ToResult};
 use crate::ptr::RPtrRepresentable;
 use jni::objects::{JObject, JString};
-use jni::sys::{jbyteArray, jobject};
+use jni::sys::{jbyteArray, jobject, jint};
 use jni::JNIEnv;
+use super::primitive::ToPrimitiveObject;
 use cardano_serialization_lib::address::{Address};
 
 // cddl_lib: (&self) -> Vec<u8>
@@ -79,6 +80,21 @@ pub extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_addressFromBech32(
     let rstr = string.string(&env)?;
     let val = Address::from_bech32(&rstr).into_result()?;
     val.rptr().jptr(&env)
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_addressNetworkId(
+  env: JNIEnv, _: JObject, ptr: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let rptr = ptr.rptr(&env)?;
+    rptr
+      .typed_ref::<Address>()
+      .map(|addr| addr.network_id())
+      .and_then(|network_id| (network_id as jint).jobject(&env))
   })
   .jresult(&env)
 }

--- a/rust/src/android/byron_address.rs
+++ b/rust/src/android/byron_address.rs
@@ -1,5 +1,5 @@
 use jni::objects::{JObject, JString};
-use jni::sys::{jobject, jboolean};
+use jni::sys::{jobject, jboolean, jlong};
 use jni::JNIEnv;
 use super::ptr_j::*;
 use super::result::ToJniResult;
@@ -73,6 +73,21 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_byronAddressFrom
       .typed_ref::<Address>()
       .map(|address| ByronAddress::from_address(address))
       .and_then(|byron_address| byron_address.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_byronAddressByronProtocolMagic(
+  env: JNIEnv, _: JObject, ptr: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let rptr = ptr.rptr(&env)?;
+    rptr
+      .typed_ref::<ByronAddress>()
+      .map(|addr| addr.byron_protocol_magic())
+      .and_then(|protocol_magic| (protocol_magic as jlong).jobject(&env))
   })
   .jresult(&env)
 }

--- a/rust/src/android/certificate.rs
+++ b/rust/src/android/certificate.rs
@@ -81,3 +81,48 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_certificateNewSt
   })
   .jresult(&env)
 }
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_certificateAsStakeRegistration(
+  env: JNIEnv, _: JObject, certificate: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let certificate = certificate.rptr(&env)?;
+    certificate
+      .typed_ref::<Certificate>()
+      .map(|certificate| certificate.as_stake_registration())
+      .and_then(|stake_registration| stake_registration.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_certificateAsStakeDeregistration(
+  env: JNIEnv, _: JObject, certificate: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let certificate = certificate.rptr(&env)?;
+    certificate
+      .typed_ref::<Certificate>()
+      .map(|certificate| certificate.as_stake_deregistration())
+      .and_then(|stake_deregistration| stake_deregistration.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_certificateAsStakeDelegation(
+  env: JNIEnv, _: JObject, certificate: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let certificate = certificate.rptr(&env)?;
+    certificate
+      .typed_ref::<Certificate>()
+      .map(|certificate| certificate.as_stake_delegation())
+      .and_then(|stake_delegation| stake_delegation.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}

--- a/rust/src/android/mod.rs
+++ b/rust/src/android/mod.rs
@@ -17,6 +17,7 @@ mod private_key;
 mod public_key;
 mod result;
 mod reward_address;
+mod reward_addresses;
 mod script_hash;
 mod stake_credential;
 mod stake_delegation;

--- a/rust/src/android/mod.rs
+++ b/rust/src/android/mod.rs
@@ -17,6 +17,7 @@ mod private_key;
 mod public_key;
 mod result;
 mod reward_address;
+mod script_hash;
 mod stake_credential;
 mod stake_delegation;
 mod stake_deregistration;

--- a/rust/src/android/reward_addresses.rs
+++ b/rust/src/android/reward_addresses.rs
@@ -1,0 +1,66 @@
+use super::primitive::ToPrimitiveObject;
+use super::ptr_j::*;
+use super::result::ToJniResult;
+use crate::panic::{handle_exception_result, Zip};
+use crate::ptr::RPtrRepresentable;
+use jni::objects::JObject;
+use jni::sys::{jobject, jlong};
+use jni::JNIEnv;
+use cardano_serialization_lib::RewardAddresses;
+use cardano_serialization_lib::address::RewardAddress;
+
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_rewardAddressesNew(
+  env: JNIEnv, _: JObject
+) -> jobject {
+  handle_exception_result(|| RewardAddresses::new().rptr().jptr(&env)).jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_rewardAddressesLen(
+  env: JNIEnv, _: JObject, reward_addresses: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let reward_addresses = reward_addresses.rptr(&env)?;
+    reward_addresses
+      .typed_ref::<RewardAddresses>()
+      .map(|reward_addresses| reward_addresses.len())
+      .and_then(|len| len.into_jlong().jobject(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_rewardAddressesGet(
+  env: JNIEnv, _: JObject, reward_addresses: JRPtr, index: jlong
+) -> jobject {
+  handle_exception_result(|| {
+    let reward_addresses = reward_addresses.rptr(&env)?;
+    reward_addresses
+      .typed_ref::<RewardAddresses>()
+      .map(|reward_addresses| reward_addresses.get(usize::from_jlong(index)))
+      .and_then(|reward_address| reward_address.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_rewardAddressesAdd(
+  env: JNIEnv, _: JObject, reward_addresses: JRPtr, item: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let reward_addresses = reward_addresses.rptr(&env)?;
+    let item = item.rptr(&env)?;
+    reward_addresses
+      .typed_ref::<RewardAddresses>()
+      .zip(item.typed_ref::<RewardAddress>())
+      .map(|(reward_addresses, item)| reward_addresses.add(item))
+  })
+  .map(|_| JObject::null())
+  .jresult(&env)
+}

--- a/rust/src/android/script_hash.rs
+++ b/rust/src/android/script_hash.rs
@@ -1,0 +1,37 @@
+use super::ptr_j::*;
+use super::result::ToJniResult;
+use crate::panic::{handle_exception_result, ToResult};
+use crate::ptr::RPtrRepresentable;
+use crate::utils::ToFromBytes;
+use super::utils::{to_bytes, from_bytes};
+use jni::objects::{JObject};
+use jni::sys::{jbyteArray, jobject};
+use jni::JNIEnv;
+use cardano_serialization_lib::crypto::{ScriptHash};
+use cardano_serialization_lib::error::{DeserializeError};
+
+impl ToFromBytes for ScriptHash {
+  fn to_bytes(&self) -> Vec<u8> {
+    self.to_bytes()
+  }
+
+  fn from_bytes(bytes: Vec<u8>) -> Result<ScriptHash, DeserializeError> {
+    ScriptHash::from_bytes(bytes)
+  }
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_scriptHashToBytes(
+  env: JNIEnv, _: JObject, script_hash: JRPtr
+) -> jobject {
+  to_bytes::<ScriptHash>(env, script_hash)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_scriptHashFromBytes(
+  env: JNIEnv, _: JObject, bytes: jbyteArray
+) -> jobject {
+  from_bytes::<ScriptHash>(env, bytes)
+}

--- a/rust/src/android/stake_credential.rs
+++ b/rust/src/android/stake_credential.rs
@@ -8,7 +8,7 @@ use super::utils::{to_bytes, from_bytes};
 use jni::objects::JObject;
 use jni::sys::{jobject, jint, jbyteArray};
 use jni::JNIEnv;
-use cardano_serialization_lib::crypto::{Ed25519KeyHash};
+use cardano_serialization_lib::crypto::{Ed25519KeyHash, ScriptHash};
 use cardano_serialization_lib::error::{DeserializeError};
 use cardano_serialization_lib::address::{StakeCredential};
 
@@ -39,12 +39,39 @@ pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_stakeCredentialF
 
 #[allow(non_snake_case)]
 #[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_stakeCredentialFromScriptHash(
+  env: JNIEnv, _: JObject, script_hash_ptr: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let script_hash = script_hash_ptr.rptr(&env)?;
+    script_hash
+      .typed_ref::<ScriptHash>()
+      .map(|script_hash| StakeCredential::from_scripthash(script_hash))
+      .and_then(|stake_credential| stake_credential.rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
 pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_stakeCredentialToKeyHash(
   env: JNIEnv, _: JObject, ptr: JRPtr
 ) -> jobject {
   handle_exception_result(|| {
     let rptr = ptr.rptr(&env)?;
     rptr.typed_ref::<StakeCredential>().and_then(|stake_credential| stake_credential.to_keyhash().rptr().jptr(&env))
+  })
+  .jresult(&env)
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_emurgo_rnhaskellshelley_Native_stakeCredentialToScriptHash(
+  env: JNIEnv, _: JObject, ptr: JRPtr
+) -> jobject {
+  handle_exception_result(|| {
+    let rptr = ptr.rptr(&env)?;
+    rptr.typed_ref::<StakeCredential>().and_then(|stake_credential| stake_credential.to_scripthash().rptr().jptr(&env))
   })
   .jresult(&env)
 }

--- a/rust/src/ios/address.rs
+++ b/rust/src/ios/address.rs
@@ -52,3 +52,14 @@ pub unsafe extern "C" fn address_from_bech32(
   handle_exception_result(|| Address::from_bech32(chars.into_str()).map(|addr| addr.rptr()).into_result())
     .response(result, error)
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn address_network_id(
+  rptr: RPtr, result: &mut u8, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    rptr.typed_ref::<Address>().map(|addr| addr.network_id())
+  })
+  .map(|network_id| network_id.into())
+  .response(result, error)
+}

--- a/rust/src/ios/byron_address.rs
+++ b/rust/src/ios/byron_address.rs
@@ -58,6 +58,19 @@ pub unsafe extern "C" fn byron_address_from_address(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn byron_address_byron_protocol_magic(
+  rptr: RPtr, result: &mut u32, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    rptr
+      .typed_ref::<ByronAddress>()
+      .map(|addr| addr.byron_protocol_magic())
+  })
+  .map(|protocol_magic| protocol_magic.into())
+  .response(result, error)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn byron_address_attributes(
   rptr: RPtr, result: &mut DataPtr, error: &mut CharPtr
 ) -> bool {

--- a/rust/src/ios/certificate.rs
+++ b/rust/src/ios/certificate.rs
@@ -71,3 +71,42 @@ pub unsafe extern "C" fn certificate_new_stake_delegation(
     .map(|certificate| certificate.rptr())
     .response(result, error)
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn certificate_as_stake_registration(
+  certificate: RPtr, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    certificate
+      .typed_ref::<Certificate>()
+      .map(|certificate| certificate.as_stake_registration())
+  })
+    .map(|stake_registration| stake_registration.rptr())
+    .response(result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn certificate_as_stake_deregistration(
+  certificate: RPtr, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    certificate
+      .typed_ref::<Certificate>()
+      .map(|certificate| certificate.as_stake_deregistration())
+  })
+    .map(|stake_deregistration| stake_deregistration.rptr())
+    .response(result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn certificate_as_stake_delegation(
+  certificate: RPtr, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    certificate
+      .typed_ref::<Certificate>()
+      .map(|certificate| certificate.as_stake_delegation())
+  })
+    .map(|stake_delegation| stake_delegation.rptr())
+    .response(result, error)
+}

--- a/rust/src/ios/mod.rs
+++ b/rust/src/ios/mod.rs
@@ -17,6 +17,7 @@ mod private_key;
 mod public_key;
 mod result;
 mod reward_address;
+mod reward_addresses;
 mod script_hash;
 mod stake_credential;
 mod stake_delegation;

--- a/rust/src/ios/mod.rs
+++ b/rust/src/ios/mod.rs
@@ -17,6 +17,7 @@ mod private_key;
 mod public_key;
 mod result;
 mod reward_address;
+mod script_hash;
 mod stake_credential;
 mod stake_delegation;
 mod stake_deregistration;

--- a/rust/src/ios/reward_addresses.rs
+++ b/rust/src/ios/reward_addresses.rs
@@ -1,0 +1,44 @@
+use super::result::CResult;
+use super::string::CharPtr;
+use crate::panic::{handle_exception, handle_exception_result, Zip};
+use crate::ptr::{RPtr, RPtrRepresentable};
+use cardano_serialization_lib::RewardAddresses;
+use cardano_serialization_lib::address::RewardAddress;
+
+
+#[no_mangle]
+pub extern "C" fn reward_addresses_new(result: &mut RPtr, error: &mut CharPtr) -> bool {
+  handle_exception(|| RewardAddresses::new().rptr()).response(result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn reward_addresses_len(
+  reward_addresses: RPtr, result: &mut usize, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| reward_addresses.typed_ref::<RewardAddresses>().map(|reward_addresses| reward_addresses.len()))
+    .response(result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn reward_addresses_get(
+  reward_addresses: RPtr, index: usize, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    reward_addresses.typed_ref::<RewardAddresses>().map(|reward_addresses| reward_addresses.get(index))
+  })
+  .map(|reward_address| reward_address.rptr())
+  .response(result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn reward_addresses_add(
+  reward_addresses: &mut RPtr, item: RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    reward_addresses
+      .typed_ref::<RewardAddresses>()
+      .zip(item.typed_ref::<RewardAddress>())
+      .map(|(reward_addresses, item)| reward_addresses.add(item))
+  })
+  .response(&mut (), error)
+}

--- a/rust/src/ios/script_hash.rs
+++ b/rust/src/ios/script_hash.rs
@@ -1,7 +1,5 @@
-use super::result::CResult;
 use super::string::{CharPtr};
-use crate::panic::{handle_exception_result};
-use crate::ptr::{RPtr, RPtrRepresentable};
+use crate::ptr::{RPtr};
 use crate::utils::ToFromBytes;
 use super::utils::{to_bytes, from_bytes};
 use super::data::DataPtr;

--- a/rust/src/ios/script_hash.rs
+++ b/rust/src/ios/script_hash.rs
@@ -1,0 +1,33 @@
+use super::result::CResult;
+use super::string::{CharPtr};
+use crate::panic::{handle_exception_result};
+use crate::ptr::{RPtr, RPtrRepresentable};
+use crate::utils::ToFromBytes;
+use super::utils::{to_bytes, from_bytes};
+use super::data::DataPtr;
+use cardano_serialization_lib::error::{DeserializeError};
+use cardano_serialization_lib::crypto::{ScriptHash};
+
+impl ToFromBytes for ScriptHash {
+  fn to_bytes(&self) -> Vec<u8> {
+    self.to_bytes()
+  }
+
+  fn from_bytes(bytes: Vec<u8>) -> Result<ScriptHash, DeserializeError> {
+    ScriptHash::from_bytes(bytes)
+  }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn script_hash_to_bytes(
+  script_hash: RPtr, result: &mut DataPtr, error: &mut CharPtr
+) -> bool {
+  to_bytes::<ScriptHash>(script_hash, result, error)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn script_hash_from_bytes(
+  data: *const u8, len: usize, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  from_bytes::<ScriptHash>(data, len, result, error)
+}

--- a/rust/src/ios/stake_credential.rs
+++ b/rust/src/ios/stake_credential.rs
@@ -7,7 +7,7 @@ use super::utils::{to_bytes, from_bytes};
 use super::data::DataPtr;
 use cardano_serialization_lib::error::{DeserializeError};
 use cardano_serialization_lib::address::{StakeCredential};
-use cardano_serialization_lib::crypto::{Ed25519KeyHash};
+use cardano_serialization_lib::crypto::{Ed25519KeyHash, ScriptHash};
 
 impl ToFromBytes for StakeCredential {
   fn to_bytes(&self) -> Vec<u8> {
@@ -32,8 +32,18 @@ pub unsafe extern "C" fn stake_credential_from_keyhash(
     .response(result, error)
 }
 
-// TODO
-// pub unsafe extern "C" fn stake_credential_from_scripthash
+#[no_mangle]
+pub unsafe extern "C" fn stake_credential_from_scripthash(
+  scripthash: RPtr, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    scripthash
+      .typed_ref::<ScriptHash>()
+      .map(|scripthash| StakeCredential::from_scripthash(scripthash))
+  })
+    .map(|stake_credential| stake_credential.rptr())
+    .response(result, error)
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn stake_credential_to_keyhash(
@@ -48,8 +58,18 @@ pub unsafe extern "C" fn stake_credential_to_keyhash(
     .response(result, error)
 }
 
-// TODO
-// pub unsafe extern "C" fn stake_credential_to_scripthash
+#[no_mangle]
+pub unsafe extern "C" fn stake_credential_to_scripthash(
+  stake_credential: RPtr, result: &mut RPtr, error: &mut CharPtr
+) -> bool {
+  handle_exception_result(|| {
+    stake_credential
+      .typed_ref::<StakeCredential>()
+      .map(|stake_credential| stake_credential.to_scripthash())
+  })
+    .map(|scripthash| scripthash.rptr())
+    .response(result, error)
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn stake_credential_to_kind(

--- a/rust/src/ptr_impl.rs
+++ b/rust/src/ptr_impl.rs
@@ -23,6 +23,7 @@ impl RPtrRepresentable for PrivateKey {}
 impl RPtrRepresentable for PublicKey {}
 impl RPtrRepresentable for RewardAddress {}
 impl RPtrRepresentable for RewardAddresses {}
+impl RPtrRepresentable for ScriptHash {}
 impl RPtrRepresentable for StakeCredential {}
 impl RPtrRepresentable for StakeDelegation {}
 impl RPtrRepresentable for StakeDeregistration {}


### PR DESCRIPTION

[x] - `Certificate::as_stake_registration()`, `as_stake_deregistration()`, `as_stake_delegation()`
[x] - `ScriptHash::to_bytes()/from_bytes()`
[x] - `StakeCredential::from_scripthash()/to_scripthash()`
[x] - `RewardAddresses` (entire class)
[x] - `ByronAddress::byron_protocol_magic()`
[x] - `Address::network_id()`